### PR TITLE
Encode URI location

### DIFF
--- a/lib/le/host/https/tcp.rb
+++ b/lib/le/host/https/tcp.rb
@@ -12,14 +12,15 @@ module Le
     class HTTPS
 
       class TCPSOCKET
+	require 'uri'
 
 	attr_accessor :sock, :conn, :key, :location
 	def initialize(key, location)
 
           @key = key
-          @location = location
+          @location = URI::encode(location)
 	  begin
-          	createSocket(key, location)
+          	createSocket(@key, @location)
 	  rescue OpenSSL::SSL::SSLError, TimeoutError, Errno::EHOSTUNREACH, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT, EOFError => e
 		$stderr.puts "WARNING: #{e.class} creating the connection to Logentries. #{e.message}"
           end


### PR DESCRIPTION
URI location wasn't properly encoded when the Logentries location included an host or log with characters that needed to be encoded (i.e.: "Master Server/application.log").

This resulted in a failure to send the logs to Logentries and some warnings on the console like, "log writing failed. Broken pipe" and "WARNING: OpenSSL::SSL::SSLError sending log SSL_write:: bad write retry".

This is not affecting the Logentries agent by the way (and that was the reason I started to check the ruby gem code).
