### PR TITLE
Fix message_in if not a string

### DIFF
--- a/lib/le/host.rb
+++ b/lib/le/host.rb
@@ -7,7 +7,7 @@ module Le
 
     module InstanceMethods
       def formatter
-        proc do |severity, datetime, progname, msg|
+        proc do |severity, datetime, _, msg|
           message = "#{datetime} "
           message << format_message(msg, severity)
         end


### PR DESCRIPTION
In rails, an exception is not always a string. I had some problems with le in production in conjunction with coalmine

I've handle this case and also did a little indentation cleaning to stick to ruby best practices.

Hope this helps.
