### PR TITLE
Only create the local log file if the local flag is set

### DIFF
--- a/lib/le/host/http.rb
+++ b/lib/le/host/http.rb
@@ -45,10 +45,12 @@ kAuBvDPPm+C0/M4RLYs=
       attr_accessor :token, :queue, :started, :thread, :conn, :local, :debug, :ssl
 
       def initialize(token, local, debug, ssl)
-        if defined?(Rails)
-          @logger_console = Logger.new("log/#{Rails.env}.log")
-        else
-          @logger_console = Logger.new(STDOUT)
+        if local
+          if defined?(Rails)
+            @logger_console = Logger.new("log/#{Rails.env}.log")
+          else
+            @logger_console = Logger.new(STDOUT)
+          end
         end
         @token = token
         @local = local


### PR DESCRIPTION
If the local flag was not set, or set to `false`, an empty log file is created and never used.  This pull request fixes that by only creating the file if the local flag is set to `true`.  This helps prevent issues in some deployments where the `log` directory does not exist in Rails applications.
