### PR TITLE
Accept multiline messages with id prefixing

### DIFF
--- a/lib/le/host/http.rb
+++ b/lib/le/host/http.rb
@@ -85,7 +85,12 @@ S5ol3bQmY1mv78XKkOk=
           @logger_console.add(Logger::Severity::UNKNOWN, message)
         end
 
-        @queue << message.gsub(/^/, "\1#{ @token } ")
+        if message.scan(/\n/).empty?
+          @queue << "#{ @token } #{ message }\n"
+        else
+          @queue << "#{ message.gsub(/^/, "\1#{ @token } [#{ random_message_id }] ") }\n"
+        end
+
 
         if @started
           check_async_thread
@@ -190,6 +195,12 @@ S5ol3bQmY1mv78XKkOk=
 
         closeConnection
       end
+
+      private
+        def random_message_id
+          @random_message_id_sample_space ||= [*'0'..'9', *'a'..'z']
+          (0..5).map{ @random_message_id_sample_space.sample }.join
+        end
     end
   end
 end


### PR DESCRIPTION
When an exception occurs in Rails or Sinatra a multiline message that includes a stack trace is pushed into log appender.
As far as I can see each line has to be signed with the token in order to get through.
I've also added a random message id to be put in the beginning of each line so that in the multiprocess logging race it was still possible to put the message together.

Are there any other/better options to push a multiline log entry?
