### PR TITLE
Fix uninitialized constant Errno::ETIMEOUT (NameError)

### DIFF
--- a/lib/le/host/http.rb
+++ b/lib/le/host/http.rb
@@ -191,7 +191,7 @@ S5ol3bQmY1mv78XKkOk=
           loop do
             begin
               @conn.write(data)
-            rescue TimeoutError, Errno::EHOSTUNREACH, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEOUT, EOFError
+            rescue TimeoutError, Errno::EHOSTUNREACH, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT, EOFError
               dbg "LE: Connection timeout(#{ $! }), try to reopen connection"
               reopenConnection
               next


### PR DESCRIPTION
Hi, I found simple misspelling bug on http.rb
Due to this, our server dies like below. Please take a look.

```
E, [2014-09-25T05:37:45.205358 #1] ERROR -- : uninitialized constant Errno::ETIMEOUT (NameError)
/opt/app/vendor/bundle/ruby/2.1.0/gems/le-2.3.9/lib/le/host/http.rb:194:in `rescue in block (2 levels) in run'
/opt/app/vendor/bundle/ruby/2.1.0/gems/le-2.3.9/lib/le/host/http.rb:192:in `block (2 levels) in run'
/opt/app/vendor/bundle/ruby/2.1.0/gems/le-2.3.9/lib/le/host/http.rb:191:in `loop'
/opt/app/vendor/bundle/ruby/2.1.0/gems/le-2.3.9/lib/le/host/http.rb:191:in `block in run'
/opt/app/vendor/bundle/ruby/2.1.0/gems/le-2.3.9/lib/le/host/http.rb:188:in `loop'
/opt/app/vendor/bundle/ruby/2.1.0/gems/le-2.3.9/lib/le/host/http.rb:188:in `run'
/opt/app/vendor/bundle/ruby/2.1.0/gems/le-2.3.9/lib/le/host/http.rb:115:in `block in start_async_thread'
```
