### PR TITLE
Fix typo

### DIFF
--- a/lib/le/host/http.rb
+++ b/lib/le/host/http.rb
@@ -265,7 +265,7 @@ S5ol3bQmY1mv78XKkOk=
           loop do
             begin
               @conn.write(data)
-            rescue TimeoutError, Errno::EHOSTUNREACH, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEOUT, EOFError
+            rescue TimeoutError, Errno::EHOSTUNREACH, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT, EOFError
               dbg "LE: Connection timeout(#{ $! }), try to reopen connection"
               reopenConnection
               next


### PR DESCRIPTION
Replace `Errno::ETIMEOUT` to `Errno::ETIMEDOUT`.

It seems to be same typo as #28.
