### PR TITLE
fix ruby 2.3 deprecation warning for using TimeoutError instead of Timeout::Error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+  - 2.3.1
   - 2.0.0
   - 1.9.3
   - jruby-19mode

--- a/lib/le/host/http.rb
+++ b/lib/le/host/http.rb
@@ -173,7 +173,7 @@ module Le
             else
               port = DATA_PORT_UNSECURE
             end
-        else      
+        else
           if @udp_port
             host = API_SERVER
             port = @udp_port
@@ -229,7 +229,7 @@ module Le
           begin
             openConnection
             break
-          rescue TimeoutError, Errno::EHOSTUNREACH, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT, EOFError
+          rescue Timeout::Error, Errno::EHOSTUNREACH, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT, EOFError
             dbg "LE: Unable to connect to Logentries due to timeout(#{ $! })"
           rescue
             dbg "LE: Got exception in reopenConnection - #{ $! }"
@@ -268,7 +268,7 @@ module Le
           loop do
             begin
               @conn.write(data)
-            rescue TimeoutError, Errno::EHOSTUNREACH, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT, EOFError
+            rescue Timeout::Error, Errno::EHOSTUNREACH, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT, EOFError
               dbg "LE: Connection timeout(#{ $! }), try to reopen connection"
               reopenConnection
               next


### PR DESCRIPTION
fixes #59 