### PR TITLE
bugfix: opt_ssl always true

### DIFF
--- a/lib/le.rb
+++ b/lib/le.rb
@@ -8,7 +8,7 @@ module Le
 
     opt_local     = options[:local]                     || false
     opt_debug     = options[:debug]                     || false
-    opt_ssl       = options[:ssl]                       || true
+    opt_ssl       = !options.include?(:ssl) ? true : options[:ssl]
     opt_tag       = options[:tag]                       || false
     opt_log_level = options[:log_level]                 || Logger::DEBUG
 


### PR DESCRIPTION
Having `opt_ssl = options[:ssl] || true` makes `opt_ssl = true` even if the user manually sets it to false. This bug made it impossible to use the Le gem to send data to Datahub without using a token. 

`logger = Le.new("", :ssl=>false, :datahub_endpoint=> ['datahub.ip.address', '10000'])`
... fails because `:ssl` gets set to `true` by the options parsing process, then https://github.com/rapid7/le_ruby/blob/master/lib/le/host/http.rb#L56 causes the program to `exit`.