### PR TITLE
LOG-10436 Fix log lines containing newline characters not being sent

### DIFF
--- a/LE.gemspec
+++ b/LE.gemspec
@@ -5,7 +5,7 @@ require 'le'
 
 Gem::Specification.new do |gem|
   gem.name	= "le"
-  gem.version	= "2.7.5"
+  gem.version	= "2.7.6"
   gem.date	= Time.now
   gem.summary	= "Logentries plugin"
   gem.licenses    = ["MIT"]

--- a/lib/le/host/http.rb
+++ b/lib/le/host/http.rb
@@ -135,7 +135,7 @@ module Le
         if message.scan(/\n/).empty?
           @queue << "#{ @token } #{ message } \n"
         else
-          @queue << "#{ message.gsub(/^/, "\1#{ @token } [#{ random_message_id }]") }\n"
+          @queue << "#{ message.gsub(/^/, "#{ @token } [#{ random_message_id }]") }\n"
         end
 
 


### PR DESCRIPTION
That `\1` was probably meant as a capture group for `^` (start of string) which doesn't make any sense to begin with, but it's the best theory I can come up with. It prepended every log line (before the log token, so LE wouldn't know what to do with it) with `\u0001`.